### PR TITLE
Debian new format fix

### DIFF
--- a/bin/freight-add
+++ b/bin/freight-add
@@ -47,6 +47,8 @@ do
 		*.deb|*.dsc|*.orig.tar.gz|*.diff.gz|*.debian.tar.gz)
 			PATHNAMES="$PATHNAMES $1"
 			shift;;
+		*.build|*.changes)
+			shift;;
 		*) break;;
 	esac
 done

--- a/bin/freight-add
+++ b/bin/freight-add
@@ -44,7 +44,7 @@ done
 while [ "$#" -gt 0 ]
 do
 	case "$1" in
-		*.deb|*.dsc|*.orig.tar.gz|*.diff.gz)
+		*.deb|*.dsc|*.orig.tar.gz|*.diff.gz|*.debian.tar.gz)
 			PATHNAMES="$PATHNAMES $1"
 			shift;;
 		*) break;;

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -369,7 +369,7 @@ apt_cache_source() {
 			echo " $SHA256 $SIZE $FILENAME"
 		done
 		echo
-	} >"$DISTCACHE/$COMP/source/Sources"
+	} >>"$DISTCACHE/$COMP/source/Sources"
 
 }
 

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -103,7 +103,7 @@ apt_cache() {
 			# and will find the associated *.orig.tar.gz and *.diff.gz as
 			# they are needed.
 			*.dsc) apt_cache_source "$DIST" "$DISTCACHE" "$PATHNAME" "$COMP" "$PACKAGE";;
-			*.diff.gz|*.orig.tar.gz) ;;
+			*.diff.gz|*.orig.tar.gz|*.debian.tar.gz) ;;
 
 			*) echo "# [freight] skipping extraneous file $PATHNAME" >&2;;
 		esac
@@ -303,7 +303,14 @@ apt_cache_source() {
 	DIRNAME="$(dirname "$PATHNAME")"
 	DSC_FILENAME="${NAME}_${VERSION%*:}.dsc"
 	ORIG_FILENAME="${NAME}_${ORIG_VERSION}.orig.tar.gz"
-	DIFF_FILENAME="${NAME}_${VERSION%*:}.diff.gz"
+	DIFFGZ_FILENAME="${NAME}_${VERSION%*:}.diff.gz"
+	DEBTAR_FILENAME="${NAME}_${VERSION%*:}.debian.tar.gz"
+
+	if [ -f "$VARLIB/apt/$DIST/$DIRNAME/$DEBTAR_FILENAME" ]; then
+		DIFF_FILENAME=${DEBTAR_FILENAME}
+	else
+		DIFF_FILENAME=${DIFFGZ_FILENAME}
+	fi
 
 	# Verify this package by ensuring the other necessary files are present.
 	[ -f "$VARLIB/apt/$DIST/$DIRNAME/$ORIG_FILENAME" \


### PR DESCRIPTION
There are 3 fixes in this pull, they should each stand on their own just fine.

Fix Sources file generation
Replaces > with >> so the Sources file generated contains all packages, not just last handled

Allow freight to handle other diff formats
$package_.debian.tar.gz is a common diff format, this allows freight to handle them for Source packages.

Freight-add ignores common unused build files
Some build files aren't handled by freight, but cause problems if included via glob in a freight-add call. This silently handles and ignores those files to avoid that problem.
