### PR TITLE
Clean up workdir after freight-cache runs

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -98,3 +98,6 @@ do
 	[ -z "$KEEP" ] && eval "${MANAGER}_clean"
 
 done
+
+# Clean up the working directory after $MANAGER is finished
+rm -rf "$TMP"


### PR DESCRIPTION
Freight-cache creates a temporary workdir but then never cleans it up. After
several runs of freight-cache, the VARCACHE gets cluttered with work.XX
directories. This adds an rm -rf on the temporary work directory to clean it up
after freight-cache has finished its work. This is also after $MANAGER has run
so the workdir isn't needed.
