### PR TITLE
Orig source can be duplicated

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -322,6 +322,8 @@ apt_cache_source() {
 	mkdir -p "$DISTCACHE/.refs/$COMP"
 	for FILENAME in "$DSC_FILENAME" "$ORIG_FILENAME" "$DIFF_FILENAME"
 	do
+		[ -e "$DISTCACHE/.refs/$COMP/$FILENAME" -a "$FILENAME" = "$ORIG_FILENAME" ] \
+		&& continue
 		ln "$VARLIB/apt/$DIST/$DIRNAME/$FILENAME" "$DISTCACHE/.refs/$COMP" ||
 		cp "$VARLIB/apt/$DIST/$DIRNAME/$FILENAME" "$DISTCACHE/.refs/$COMP"
 	done


### PR DESCRIPTION
If there are packaging changes to a package without an upstream change, there
can be multiple sources to the same orig.tar.gz. For example,
package_1.2.3-1ubuntu1 and package_1.2.3-1ubuntu2 would both have the same
package_1.2.3.orig.tar.gz. This is a problem because freight-cache tries to
link or copy the orig.tar.gz more than once to the same pool, which generates
an error and terminates the freight-cache run.

This patch adds a check to see if the link or file already exists and is the
orig.tar.gz for the current package. If there is such a file the loop
continues. Another effective strategy here would be to just check if the file
exists as on line 339.
