### PR TITLE
Add freight-init. freight-init will configure freight to have a all-in-one workdir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.diff.gz
 etc/freight.conf
 var
+*~

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all:
 
 clean:
 	rm -rf *.deb debian man/man*/*.html
+	find . -name '*~' -delete
 
 install: install-bin install-lib install-man install-sysconf
 

--- a/bin/freight
+++ b/bin/freight
@@ -14,6 +14,6 @@ COMMAND=$0-$1
 
 # Be helpful in this case since no subcommand was found.
 echo "Usage: $(basename $0) <command> [...]" >&2
-echo "Common commands: add cache" >&2
+echo "Common commands: add cache init" >&2
 echo "See all available commands by typing \"$(basename $0)-<TAB><TAB>\"" >&2
 exit 1

--- a/bin/freight-init
+++ b/bin/freight-init
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+# Initialize a "freight" directory (similar to git init)
+
+set -e
+
+# Combined usage message and help screen.
+usage() {
+	echo "Usage: $(basename $0) [-l <libdir>] [--cache <cachedir>] [-v] [-h] -g <gpg> dir" >&2
+	[ -n "$1" ] && {
+		echo "  -g <gpg>, --gpg=<gpg>          GPG key to use" >&2
+		echo "  -l <libdir>, --libdir=<libdir> VARLIB dir to set" >&2
+		echo "  --cache=<cachedir>             VARCACHE dir to set" >&2
+		echo "  -v, --verbose                  verbose mode" >&2
+		echo "  -h, --help                     show this help message" >&2
+	} && exit 0 || exit 1
+}
+
+# `getopts` doesn't support long options so this will have to do.
+while [ "$#" -gt 0 ]
+do
+	case "$1" in
+		-g|--gpg)
+			GPG="$2"
+			shift 2;;
+		--gpg=*)
+			GPG="$(echo $1 | cut -c7-)"
+			shift;;
+		-l|--libdir)
+			VARLIB="$2"
+			shift 2;;
+		--libdir=*)
+			VARLIB="$(echo $1 | cut -c10-)"
+			shift;;
+		--cachedir)
+			VARCACHE="$2"
+			shift 2;;
+		--cachedir=*)
+			VARCACHE="$(echo $1 | cut -c12-)"
+			shift;;
+		-v|--verbose)
+			VERBOSE=1
+			shift;;
+		-h|--help) usage help;;
+		-*) echo "# [freight] unknown switch: $1" >&2;;
+		*) break;;
+	esac
+done
+
+DIR="$1"
+if [ -z "$DIR" ]; then
+    usage
+fi
+if [ -z "$GPG" ]; then
+    usage
+fi
+
+# Set VARLIB and VARCACHE to DIR/lib and DIR/cache
+# unless otherwise configured.
+VARLIB="${VARLIB:-$DIR/lib}"
+VARCACHE="${VARCACHE:-$DIR/cache}"
+
+# Initialize directory
+mkdir -p "$DIR" "$VARLIB" "$VARCACHE"
+
+# Generate a .freight.conf
+cat >"$DIR/.freight.conf" <<-EOF
+	VARLIB="$VARLIB"
+	VARCACHE="$VARCACHE"
+	GPG="$GPG"
+	EOF
+
+#  And small wrappers for (freight-add|freight-cache)
+BINARIES="freight-add freight-cache"
+for binary in $BINARIES; do
+    cat >"$DIR/$binary" <<-EOF
+	#! /bin/sh
+	$binary -c "\$(dirname "\$0")/.freight.conf" "\$@"
+	EOF
+    chmod a+x "$DIR/$binary"
+done

--- a/man/man1/freight-init.1.ronn
+++ b/man/man1/freight-init.1.ronn
@@ -1,0 +1,44 @@
+freight-init(1) -- initialize a Freight directory
+=================================================
+
+## SYNOPSIS
+
+`freight init` [`-l` _libdir_] [`--cache` _cachedir_] `-g` _gpg_ _dir_
+
+## DESCRIPTION
+
+`freight-init` will setup a directory to be used by Freight. It will generate small wrappers around the original freight-commands. Use `./freight-add` and `./freight-cache` to work against the `libdir` and `cachedir` given to `freight init`.
+
+The benefit of using `freight-init` is, that all data is stored in one place and dont have to pass `-c _conf_` option all the time.
+
+Configuration is stored in `_dir_/.freight.conf`.
+
+## OPTIONS
+
+* `-g` _gpg_, `--gpg=`_gpg_`:
+  GPG signing key
+* `-l` _libdir_, `--libdir=`_libdir`_:
+  VARLIB directory to use. Defaults to `_dir_/lib`
+* `--cachedir=`_cachedir`_:
+  VARCACHE directory to use. Defaults to `_dir_/cache`
+* `-v`, `--verbose`:
+  Verbose mode.
+* `-h`, `--help`:
+  Show a help message.
+
+## FILES
+
+* _/freight.conf_:
+  The default configuration file.  See `freight`(5).
+
+## THEME SONG
+
+The New Pornographers - "All the Old Showstoppers"
+
+## AUTHOR
+
+Jens Braeuer <braeuer.jens@googlemail.com>
+
+## SEE ALSO
+
+Part of `freight`(1).


### PR DESCRIPTION
Hi,

I create "freight-init" which will setup a freight "workdir" similar to "git init". It does so, by generating the conf-file and small wrapper around freight-add and freight-cache.

The big advantage of this, that everything is stored in one place and one does not need to pass "-c conf" every time. This comes handy, when running freight as non-root (no right to write to /var/) or when having multiple work-dirs. I run multiple workdirs for CI, Staging, etc.

I added a manual-page in .ronn format but I was unable to re-generate the .man-page. So a doc-rebuild run is needed.

Cheers,
Jens
