### PR TITLE
Use MD5sum (lower s) for Packages file

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -270,7 +270,7 @@ apt_cache_binary() {
 		grep -v "^(Essential|Filename|MD5Sum|SHA1|SHA256|Size)"
 		cat <<EOF
 Filename: $POOL/$FILENAME
-MD5Sum: $(apt_md5 "$VARLIB/apt/$DIST/$PATHNAME")
+MD5sum: $(apt_md5 "$VARLIB/apt/$DIST/$PATHNAME")
 SHA1: $(apt_sha1 "$VARLIB/apt/$DIST/$PATHNAME")
 SHA256: $(apt_sha256 "$VARLIB/apt/$DIST/$PATHNAME")
 Size: $(apt_filesize "$VARLIB/apt/$DIST/$PATHNAME")


### PR DESCRIPTION
The Packages file uses MD5sum (lower s), as seen in http://archive.debian.org/debian-backports/dists/sarge-backports/contrib/binary-i386/Packages while the Release file uses MD5Sum. Some programs like apt-mirror are case sensitive and break when confronted with MD5Sum in a Packages file. (Thanks for the consistency debian.)
