### PR TITLE
Fix freight-init exitcode.

### DIFF
--- a/bin/freight-init
+++ b/bin/freight-init
@@ -69,3 +69,6 @@ EOF
 [ "$ARCHS" ] && echo "ARCHS=\"$ARCHS\"" >>"$CONF"
 [ "$ORIGIN" ] && echo "ORIGIN=\"$ORIGIN\"" >>"$CONF"
 [ "$LABEL" ] && echo "LABEL=\"$LABEL\"" >>"$CONF"
+
+# return 0 when we come here
+exit 0


### PR DESCRIPTION
fright-init would exit with 1 when LABEL is not set. Fix this detail.
