### PR TITLE
Update FPM invocation in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ uninstall-sysconf:
 
 build:
 	make install prefix=/usr sysconfdir=/etc DESTDIR=debian
-	fpm -s dir -t deb -C debian \
-		-n freight -v $(VERSION)-$(BUILD) -a all \
+	fpm -s dir -t deb -C debian . \
+		-n freight -v $(VERSION) --iteration $(BUILD) -a all \
 		-d coreutils -d dash -d dpkg -d gnupg -d grep \
 		-m "Richard Crowley <r@rcrowley.org>" \
 		--url "https://github.com/rcrowley/freight" \


### PR DESCRIPTION
FPM 0.4.0 barfs if you don't specify a path when using `-s dir`, so I've added the `.`. Also, there's been a separate option for specifying the iteration for a little while now, so I've separated that out.

Both of these changes work with FPM 0.3.11 also.
