### PR TITLE
Add Suite field to Release file

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -147,6 +147,7 @@ EOF
 		cat <<EOF
 Origin: $ORIGIN
 Label: $LABEL
+Suite: $DIST
 Codename: $DIST
 Components: $(echo "$COMPS" | tr \\n " ")
 Architectures: $ARCHS


### PR DESCRIPTION
Apparently older versions of unattended-upgrades require the Suite field in the
Release file to function. This commit adds a Suite field which mirrors the
Codename, or $DIST.
