### PR TITLE
Add source and binary control caching

### DIFF
--- a/bin/freight-clear-cache
+++ b/bin/freight-clear-cache
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# Clear the cache that is built up during freight-cache runs
+# so that it can be regenerated on the next freight-cache invocation.
+
+#/ Usage: freight clear-cache [-c <conf>] [-v] [-h] [<manager>/<distro>][...]
+#/   -c <conf>, --conf=<conf>  config file to parse
+#/   -v, --verbose             verbose mode
+#/   -h, --help                show this help message
+
+set -e
+
+usage() {
+	grep "^#/" "$0" | cut -c"4-" >&2
+	exit "$1"
+}
+while [ "$#" -gt 0 ]
+do
+	case "$1" in
+		-c|--conf) CONF="$2" shift 2;;
+		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
+		--conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
+		-v|--verbose) VERBOSE=1 shift;;
+		-h|--help) usage 0;;
+		-*) echo "# [freight] unknown switch: $1" >&2;;
+		*) break;;
+	esac
+done
+
+. "$(dirname "$(dirname "$0")")/lib/freight/conf.sh"
+
+# Create a working directory on the same device as the Freight cache.
+mkdir -p "$VARCACHE"
+TMP="$(mktemp -d "$VARCACHE/work.$$.XXXXXXXXXX")"
+trap "rm -rf \"$TMP\"" EXIT INT TERM
+
+# Enter the Freight library directory so that items in `$@` may be given as
+# absolute paths or as partial paths of the form `<manager>/<distro>` that
+# are ultimately taken relative to the Freight library.
+mkdir -p "$VARLIB"
+cd "$VARLIB"
+
+# Rebuild each distro serially.
+if [ -z "$*" ]
+then
+	DIRS="$(
+		find "$VARLIB" -mindepth 2 -maxdepth 2 -type d -printf "%P\n" |
+		grep -v "^\\." |
+		tr "\n" " "
+	)"
+else
+	DIRS="$@"
+fi
+for DIR in $DIRS
+do
+
+	# Parse the manager and distro out of the Freight library path.
+	DIR="$(readlink -f "$DIR")"
+	DIR="${DIR##"$VARLIB/"}"
+	MANAGER="$(dirname "$DIR")"
+	DIST="$(basename "$DIR")"
+
+	# From here the process is customized on a per-manager basis.
+	. "$(dirname "$(dirname "$0")")/lib/freight/$MANAGER.sh"
+	eval "${MANAGER}_clear_cache" "$DIST"
+
+done

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -9,6 +9,10 @@ VARCACHE="/var/cache/freight"
 ORIGIN="Freight"
 LABEL="Freight"
 
+# Whether or not Freight should regenerate all of the control files for each
+# run.
+CACHE="off"
+
 # GPG key to use to sign repositories.  This is required by the `apt`
 # repository provider.  Use `gpg --gen-key` (see `gpg`(1) for more
 # details) to generate a key and put its email address here.

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -9,8 +9,7 @@ VARCACHE="/var/cache/freight"
 ORIGIN="Freight"
 LABEL="Freight"
 
-# Whether or not Freight should regenerate all of the control files for each
-# run.
+# Cache the control files after each run (on), or regenerate them every time (off)
 CACHE="off"
 
 # GPG key to use to sign repositories.  This is required by the `apt`

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -20,6 +20,10 @@ apt_binary_arch() {
 	apt_info "$1" Architecture
 }
 
+apt_binary_filesize() {
+	apt_info "$1" Size
+}
+
 # Print the source name from the given control file.
 apt_binary_sourcename() {
 	SOURCE="$(apt_info "$1" Source)"
@@ -233,7 +237,10 @@ apt_cache_binary() {
 	else
 		CONTROL="$TMP/DEBIAN/binary-control"
 	fi
-	if ! [ -e "$CONTROL" ]; then
+	# If caching is off or if the binary has changed size, this will generate the
+	# binary control file
+	if ! ( [ -e "$CONTROL" ] && \
+		[ "$(apt_binary_filesize "$CONTROL")" -eq "$(apt_filesize "$VARLIB/apt/$DIST/$PATHNAME")" ] ); then
 		dpkg-deb -e "$VARLIB/apt/$DIST/$PATHNAME" "$TMP/DEBIAN" || {
 			echo "# [freight] skipping invalid Debian package $PATHNAME" >&2
 			return

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -105,7 +105,7 @@ apt_cache() {
 			# and will find the associated *.orig.tar.gz and *.diff.gz as
 			# they are needed.
 			*.dsc) apt_cache_source "$DIST" "$DISTCACHE" "$PATHNAME" "$COMP" "$PACKAGE";;
-			*.debian.tar.gz|*.diff.gz|*.orig.tar.gz) ;;
+			*.debian.tar.gz|*.diff.gz|*.orig.tar.gz|*.deb-control) ;;
 
 			*) echo "# [freight] skipping extraneous file $PATHNAME" >&2;;
 		esac
@@ -217,10 +217,37 @@ apt_cache_binary() {
 
 	# Verify this package by way of extracting its control information
 	# to be used throughout this iteration of the loop.
-	dpkg-deb -e "$VARLIB/apt/$DIST/$PATHNAME" "$TMP/DEBIAN" || {
-		echo "# [freight] skipping invalid Debian package $PATHNAME" >&2
-		return
-	}
+	# Don't extract the deb archive each time. Stick the control file
+	# in the $VARLIB alongside the other package artifacts for easy
+	# use later.
+	CONTROL="$VARLIB/apt/$DIST/$PATHNAME-control"
+	if ! [ -e "$CONTROL" ]; then
+		dpkg-deb -e "$VARLIB/apt/$DIST/$PATHNAME" "$TMP/DEBIAN" || {
+			echo "# [freight] skipping invalid Debian package $PATHNAME" >&2
+			return
+		}
+		{
+			# Grab and augment the control file from this package.  Remove
+			# `Size`, `MD5Sum`, etc. lines and replace them with newly
+			# generated values. Update it once when generating the
+			# cached control file. Add a Filename line that can be updated
+			# easily later with the real path.
+			grep . "$TMP/DEBIAN/control" |
+			grep -v "^(Essential|Filename|MD5Sum|SHA1|SHA256|Size)"
+			cat <<EOF
+Filename: FILENAME
+MD5sum: $(apt_md5 "$VARLIB/apt/$DIST/$PATHNAME")
+SHA1: $(apt_sha1 "$VARLIB/apt/$DIST/$PATHNAME")
+SHA256: $(apt_sha256 "$VARLIB/apt/$DIST/$PATHNAME")
+Size: $(apt_filesize "$VARLIB/apt/$DIST/$PATHNAME")
+EOF
+		echo
+		} > "$CONTROL"
+		# Cleanup the extracted package
+		if [ -d "$TMP/DEBIAN" ]; then
+			rm -rf "$TMP/DEBIAN"
+		fi
+	fi
 
 	# Create all architecture-specific directories.  This will allow
 	# packages marked `all` to actually be placed in all architectures.
@@ -237,7 +264,6 @@ apt_cache_binary() {
 
 	# Package properties.  Remove the epoch from the version number
 	# in the package filename, as is customary.
-	CONTROL="$TMP/DEBIAN/control"
 	ARCH="$(apt_binary_arch "$CONTROL")"
 	NAME="$(apt_binary_name "$CONTROL")"
 	VERSION="$(apt_binary_version "$CONTROL")"
@@ -264,23 +290,10 @@ apt_cache_binary() {
 	else FILES="$DISTCACHE/$COMP/binary-$ARCH/Packages"
 	fi
 
-	# Grab and augment the control file from this package.  Remove
-	# `Size`, `MD5Sum`, etc. lines and replace them with newly
-	# generated values.  Add the `Filename` field containing the
-	# path to the package, starting with `pool/`.
-	{
-		grep . "$TMP/DEBIAN/control" |
-		grep -v "^(Essential|Filename|MD5Sum|SHA1|SHA256|Size)"
-		cat <<EOF
-Filename: $POOL/$FILENAME
-MD5sum: $(apt_md5 "$VARLIB/apt/$DIST/$PATHNAME")
-SHA1: $(apt_sha1 "$VARLIB/apt/$DIST/$PATHNAME")
-SHA256: $(apt_sha256 "$VARLIB/apt/$DIST/$PATHNAME")
-Size: $(apt_filesize "$VARLIB/apt/$DIST/$PATHNAME")
-EOF
-		echo
-	} | tee -a $FILES >/dev/null
-	rm -rf "$TMP/DEBIAN"
+	# Add the `Filename` field containing the path to the
+	# package, starting with `pool/`.
+	sed "s,^Filename: FILENAME$,Filename: $POOL/$FILENAME,g" "$CONTROL" |
+	tee -a $FILES >/dev/null
 
 }
 
@@ -348,6 +361,7 @@ apt_cache_source() {
 	# Grab and augment the control fields from this source package.  Remove
 	# and recalculate file checksums.  Change the `Source` field to `Package`.
 	# Add the `Directory` field.
+	echo "apt_cache_source with PATHNAME of $VARLIB/apt/$DIST/$PATHNAME"
 	{
 		egrep "^[A-Z][^:]+: ." "$VARLIB/apt/$DIST/$PATHNAME" |
 		egrep -v "^(Version: GnuPG|Hash: )" |

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -207,6 +207,14 @@ EOF
 
 }
 
+# Clear the cached control files from the dist
+apt_clear_cache() {
+	# First remove the binary control cache
+	find "$VARLIB/apt/$DIST" -name *-control | xargs --no-run-if-empty rm
+	# Next remove the source control cache
+	find "$VARLIB/apt/$DIST" -name *-cached | xargs --no-run-if-empty rm
+}
+
 # Add a binary package to the given dist and to the pool.
 apt_cache_binary() {
 	DIST="$1"
@@ -223,7 +231,7 @@ apt_cache_binary() {
 	if [ "$CACHE" = "on" ]; then
 		CONTROL="$VARLIB/apt/$DIST/$PATHNAME-control"
 	else
-		CONTROL="$TMP/DEBIAN/control"
+		CONTROL="$TMP/DEBIAN/binary-control"
 	fi
 	if ! [ -e "$CONTROL" ]; then
 		dpkg-deb -e "$VARLIB/apt/$DIST/$PATHNAME" "$TMP/DEBIAN" || {
@@ -369,7 +377,7 @@ apt_cache_source() {
 	if [ "$CACHE" = "on" ]; then
 		CONTROL="$VARLIB/apt/$DIST/$PATHNAME-cached"
 	else
-		CONTROL="$TMP/$PATHNAME"
+		CONTROL="$TMP/source-control"
 	fi
 	if ! [ -e "$CONTROL" ]; then
 		{
@@ -406,8 +414,8 @@ apt_cache_source() {
 	tee -a "$DISTCACHE/$COMP/source/Sources" >/dev/null
 
 # Clean up the tmp space
-	if [ -f "$TMP/$PATHNAME" ]; then
-		rm "$TMP/$PATHNAME"
+	if [ -f "$TMP/source-control" ]; then
+		rm "$TMP/source-control"
 	fi
 
 }

--- a/lib/freight/conf.sh
+++ b/lib/freight/conf.sh
@@ -12,6 +12,8 @@ ARCHS="i386 amd64"
 ORIGIN="Freight"
 LABEL="Freight"
 
+CACHE="off"
+
 # Source all existing configuration files from lowest- to highest-priority.
 PREFIX="$(dirname $(dirname $0))"
 if [ "$PREFIX" = "/usr" ]


### PR DESCRIPTION
These commits add basic source and binary control caching to avoid the potentially expensive hashing operations against binary files that occur on each freight-cache run. They also add a freight.conf setting to toggle this new behavior, defaulting to false to preserve current behavior and a new binary to clear the cache of these files.

On test runs with a repo of 313 debs and about 50 source packages, the caching improved freight-cache run times from 20 seconds to 8 or 9 seconds.

<pre>
Current master:
# time freight-cache

real    0m19.794s
user    0m3.712s
sys 0m1.272s


With control file (from .deb extraction) caching:

First cold run:

real    0m20.015s
user    0m3.816s
sys 0m1.396s

First hot run:

real    0m12.793s
user    0m1.812s
sys 0m0.800s


With source caching (from .dsc file) [aggregate with control file caching]:

First cold run:

real    0m20.181s
user    0m3.824s
sys 0m1.376s

First hot run:

real    0m8.788s
user    0m0.108s
sys 0m0.448s
</pre>
