### PR TITLE
Provide config option to create symlink components

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -67,13 +67,16 @@ do
 	MANAGER="$(dirname "$DIR")"
 	DIST="$(basename "$DIR")"
 
+  # Check to see if we should obey symlinked components in the libdir
+  [ -n "$SYMLINKS" ] && LINK="-L"
+
 	# From here the process is customized on a per-manager basis.  The
 	# sorted list of package filenames comes on `stdin` and the name of
 	# the distro is the only argument.  From there, each manager can do
 	# whatever it wants.
 	. "$(dirname "$(dirname "$0")")/lib/freight/$MANAGER.sh"
 	SORT="$(sort -V <"/dev/null" 2>"/dev/null" && echo "sort -V" || echo "sort")"
-	find "$DIR" -type f -printf "%P\n" 2>"/dev/null" |
+	find "$LINK" "$DIR" -type f -printf "%P\n" 2>"/dev/null" |
 	eval "$SORT" |
 	eval "${MANAGER}_cache" "$DIST"
 

--- a/etc/freight.conf.example
+++ b/etc/freight.conf.example
@@ -16,3 +16,7 @@ CACHE="off"
 # repository provider.  Use `gpg --gen-key` (see `gpg`(1) for more
 # details) to generate a key and put its email address here.
 GPG="example@example.com"
+
+# Should we follow symlinks in the lib directory to produce extra components
+# in the cache directory (present) or not (absent)
+# SYMLINKS=true


### PR DESCRIPTION
I have a project with a deb repo (which is managed by Freight, obviously) in which I would like to have a component for each major release (easy) but also to have a "stable" component pointing to the latest release. So

```
deb http://myproject/ projectname 1.1
deb http://myproject/ projectname 1.2
deb http://myproject/ projectname stable
```

I could create this simply by copying the debs from the `$VARLIB/apt/project/1.2` directory to the `stable` directory, but this is space inefficient, and with Jenkins publishing new packages to _only_ the 1.2 repo, risks packages being missed over time.

Attached is a patch to optionally allow the `find` command in freight-cache to discover debs within symlinked directories. Using this, one sets SYMLINKS=true in the freight.conf and then simply does `ln 1.2 stable` in VARLIB.

It seems to work for my limited testing - here's some testing output:

```
# some ls output
-rw-r--r-- 5 root root 74K Sep 16 16:38 lib/apt/squeeze/1.3/facter_1.7.3-1puppetlabs1_amd64.deb
lrwxrwxrwx 1 root root   3 Sep 16 16:46 lib/apt/squeeze/rc -> 1.3

# without SYMLINKS
$ grep SYMLINK  freight.conf 
#SYMLINKS=true
$ /root/freight/bin/freight-cache -v -c ./freight.conf 
# [freight] adding facter_1.7.3-1puppetlabs1_amd64.deb to pool

# with SYMLINKS
$ grep SYMLINK  freight.conf 
SYMLINKS=true
$ /root/freight/bin/freight-cache -v -c ./freight.conf 
# [freight] adding facter_1.7.3-1puppetlabs1_amd64.deb to pool
# [freight] adding facter_1.7.3-1puppetlabs1_amd64.deb to pool
```

Obviously that's not massively verbose, but you can see it's picked up the same deb twice, once for the real repo and once for the symlink.

Hopefully it's useful, opinions welcome! (oh, and thanks @rcrowley for the awesome project)
