### PR TITLE
Optionally read GPG key passphrase from file

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -4,12 +4,14 @@
 # actual repositories that are suitable targets for `apt-get` (and maybe
 # more in the future).
 
-#/ Usage: freight cache [-k] [-g <email>] [-c <conf>] [-v] [-h] [<manager>/<distro>][...]
-#/   -k, --keep                keep unreferenced versions of packages
-#/   -g <email>, --gpg=<email> GPG key to use
-#/   -c <conf>, --conf=<conf>  config file to parse
-#/   -v, --verbose             verbose mode
-#/   -h, --help                show this help message
+#/ Usage: freight cache [-k] [-g <email>] [-p <passphrase file>] [-c <conf>] [-v] [-h] [<manager>/<distro>][...]
+#/   -k, --keep                          keep unreferenced versions of packages
+#/   -g <email>, --gpg=<email>           GPG key to use
+#/   -p <passphrase file>, 
+#/   --passphrase-file=<passphrase file> path to file containing the passphrase of the GPG key
+#/   -c <conf>, --conf=<conf>            config file to parse
+#/   -v, --verbose                       verbose mode
+#/   -h, --help                          show this help message
 
 set -e
 
@@ -24,6 +26,9 @@ do
 		-g|--gpg) GPG="$2" shift 2;;
 		-g*) GPG="$(echo "$1" | cut -c"3-")" shift;;
 		--gpg=*) GPG="$(echo "$1" | cut -c"7-")" shift;;
+		-p|--passphrase-file) GPG_PASSPHRASE_FILE="$2" shift 2;;
+		-p*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"3-")" shift;;
+		--passphrase-file=*) GPG_PASSPHRASE_FILE="$(echo "$1" | cut -c"19-")" shift;;
 		-c|--conf) CONF="$2" shift 2;;
 		-c*) CONF="$(echo "$1" | cut -c"3-")" shift;;
 		--conf=*) CONF="$(echo "$1" | cut -c"8-")" shift;;
@@ -35,6 +40,10 @@ do
 done
 
 . "$(dirname "$(dirname "$0")")/lib/freight/conf.sh"
+
+# If GPG_PASSPHRASE_FILE is set the specified file should 
+# exist and be readable by the user running Freight
+[ "$GPG_PASSPHRASE_FILE" ] && ( [ -r "$GPG_PASSPHRASE_FILE" ] || echo "Could not read passphrase file ${GPG_PASSPHRASE_FILE}." >&2 )
 
 # Create a working directory on the same device as the Freight cache.
 mkdir -p "$VARCACHE"

--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -182,6 +182,7 @@ EOF
 
 	# Sign the top-level `Release` file with `gpg`.
 	gpg -abs$([ "$TTY" ] || echo " --no-tty") --use-agent -u"$GPG" \
+		$([ "$GPG_PASSPHRASE_FILE" ] && echo " --batch --passphrase-fd 1 --passphrase-file ${GPG_PASSPHRASE_FILE}") \
 		-o"$DISTCACHE/Release.gpg" "$DISTCACHE/Release" || {
 		cat <<EOF
 # [freight] couldn't sign the repository, perhaps you need to run

--- a/man/man1/freight-add.1
+++ b/man/man1/freight-add.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT\-ADD" "1" "January 2012" "" "Freight"
+.TH "FREIGHT\-ADD" "1" "September 2013" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\-add\fR \- add a package to Freight
 .
 .SH "SYNOPSIS"
-\fBfreight add\fR [\fB\-c\fR \fIconf\fR] [\fB\-v\fR] [\fB\-h\fR] \fIpackage\fR \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR][\|\.\|\.\|\.]
+\fBfreight add\fR [\fB\-c\fR \fIconf\fR] [\fB\-v\fR] [\fB\-h\fR] \fIpackage\fR \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR][\.\.\.]
 .
 .SH "DESCRIPTION"
 \fBfreight\-add\fR registers the given package with one or more \fImanager\fR/\fIdistro\fR[/\fIcomponent\fR] pairs (triples)\. Currently, \fBapt\fR is the only supported \fImanager\fR\. \fIdistro\fR may be any arbitrary value but is best suited to naming a particular version of the target operating system (for example, "lenny" or "lucid")\. \fIcomponent\fR is optional and for \fBapt\fR defaults to \fBmain\fR\.

--- a/man/man1/freight-cache.1
+++ b/man/man1/freight-cache.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT\-CACHE" "1" "January 2012" "" "Freight"
+.TH "FREIGHT\-CACHE" "1" "September 2013" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\-cache\fR \- (re)builds package repositories
 .
 .SH "SYNOPSIS"
-\fBfreight cache\fR [\fB\-k\fR] [\fB\-g\fR \fIemail\fR] [\fB\-c\fR \fIconf\fR] [\fB\-v\fR] [\fB\-h\fR] [\fImanager\fR/\fIdistro\fR][\|\.\|\.\|\.]
+\fBfreight cache\fR [\fB\-k\fR] [\fB\-g\fR \fIemail\fR] [\fB\-p\fR \fIpassphrase file\fR] [\fB\-c\fR \fIconf\fR] [\fB\-v\fR] [\fB\-h\fR] [\fImanager\fR/\fIdistro\fR][\.\.\.]
 .
 .SH "DESCRIPTION"
 \fBfreight\-cache\fR converts each \fImanager\fR/\fIdistro\fR given into a package repository (only Debian archives are supported currently)\. The \fImanager\fR indicates the type of repository (again, \fBapt\fR is the only supported value)\. The \fIdistro\fR is an arbitrary string that should match a release of the target operating system (for example, "lenny" or "lucid")\. If none are given, \fBfreight\-cache\fR converts all \fImanager\fR/\fIdistro\fR pairs found in \fB$VARLIB\fR\.
@@ -30,6 +30,10 @@ Keep unreferenced versions of packages\. This is different than keeping multiple
 .TP
 \fB\-g\fR \fIemail\fR, \fB\-\-gpg=\fR\fIemail\fR
 Use an alternate GPG key\.
+.
+.TP
+\fB\-p\fR \fIpassphrase file\fR, \fB\-\-passphrase\-file=\fR\fIpassphrase file\fR
+Use an alternate file containing the GPG key passphrase\. This file should obviously be protected and only readable by the user running Freight\.
 .
 .TP
 \fB\-c\fR \fIconf\fR, \fB\-\-conf=\fR\fIconf\fR

--- a/man/man1/freight-cache.1.ronn
+++ b/man/man1/freight-cache.1.ronn
@@ -3,7 +3,7 @@ freight-cache(1) -- (re)builds package repositories
 
 ## SYNOPSIS
 
-`freight cache` [`-k`] [`-g` _email_] [`-c` _conf_] [`-v`] [`-h`] [_manager_/_distro_][...]  
+`freight cache` [`-k`] [`-g` _email_] [`-p` _passphrase file_] [`-c` _conf_] [`-v`] [`-h`] [_manager_/_distro_][...]  
 
 ## DESCRIPTION
 
@@ -21,6 +21,8 @@ From version 0.0.8 onwards, distros in an APT repository no longer share the con
   Keep unreferenced versions of packages.  This is different than keeping multiple versions of a package in the repository, which is supported without any special options.
 * `-g` _email_, `--gpg=`_email_:
   Use an alternate GPG key.
+* `-p` _passphrase file_, `--passphrase-file=`_passphrase file_:
+  Use an alternate file containing the GPG key passphrase. This file should obviously be protected and only readable by the user running Freight.
 * `-c` _conf_, `--conf=`_conf_:
   Use an alternate configuration file.
 * `-v`, `--verbose`:

--- a/man/man1/freight.1
+++ b/man/man1/freight.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT" "1" "January 2012" "" "Freight"
+.TH "FREIGHT" "1" "September 2013" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\fR \- a modern take on the Debian archive
 .
 .SH "SYNOPSIS"
-\fBfreight\fR \fIcommand\fR [\fI\|\.\|\.\|\.\fR]
+\fBfreight\fR \fIcommand\fR [\fI\.\.\.\fR]
 .
 .SH "DESCRIPTION"
 \fBfreight\fR programs create the files needed to serve a Debian archive\. The actual serving is done via your favorite HTTP server\.

--- a/man/man5/freight.5
+++ b/man/man5/freight.5
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "FREIGHT" "5" "January 2012" "" "Freight"
+.TH "FREIGHT" "5" "September 2013" "" "Freight"
 .
 .SH "NAME"
 \fBfreight\fR \- Freight configuration
@@ -34,6 +34,10 @@ The \fBLabel\fR field in the Debian archive\.
 .TP
 \fBGPG\fR
 The GPG key to use\. This value must be set either in a configuration file or by using the \fB\-g\fR option to \fBfreight\-cache\fR(1)\.
+.
+.TP
+\fBGPG_PASSPHRASE_FILE\fR
+Path to a file containing the GPG key passphrase\. Useful for running Freight non\-interactively\. If set \fBgpg\fR will use the passphrase contained in the specified file and not ask for user input\. This file should obviously be protected and only readable by the Freight system user\. The passphrase file can be set in a configuration file or by using the \fB\-p\fR option to \fBfreight\-cache\fR(1)\.
 .
 .SH "FILES"
 .

--- a/man/man5/freight.5.ronn
+++ b/man/man5/freight.5.ronn
@@ -19,6 +19,8 @@ The Freight configuration is a `source`d shell script that defines a few importa
   The `Label` field in the Debian archive.
 * `GPG`:
   The GPG key to use.  This value must be set either in a configuration file or by using the `-g` option to `freight-cache`(1).
+* `GPG_PASSPHRASE_FILE`:
+  Path to a file containing the GPG key passphrase.  Useful for running Freight non-interactively. If set `gpg` will use the passphrase contained in the specified file and not ask for user input. This file should obviously be protected and only readable by the Freight system user. The passphrase file can be set in a configuration file or by using the `-p` option to `freight-cache`(1).
 
 ## FILES
 


### PR DESCRIPTION
gpg supports reading a key's passphrase from a specified file. This
commit adds a new configuration option `GPG_PASSPHRASE_FILE` and related
commandline options `-p|--passphrase-file` to `freight-cache` which
allow specifying the file from which to read the GPG key's passphrase
when signing the Release file. Allows for running Freight
non-interactively and without asking for user input which can be
desirable in certain situations. Addresses issue #33.
