### PR TITLE
Creating directories now friendlier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,21 +16,17 @@ clean:
 install: install-bin install-lib install-man install-sysconf
 
 install-bin:
-	install -d $(DESTDIR)$(bindir)
-	find bin -type f -printf %P\\0 | xargs -0r -I__ install bin/__ $(DESTDIR)$(bindir)/__
+	find bin -type f -printf %P\\0 | xargs -0r -I__ install -D bin/__ $(DESTDIR)$(bindir)/__
 
 install-lib:
-	find lib -type d -printf %P\\0 | xargs -0r -I__ install -d $(DESTDIR)$(libdir)/__
-	find lib -type f -printf %P\\0 | xargs -0r -I__ install -m644 lib/__ $(DESTDIR)$(libdir)/__
+	find lib -type f -printf %P\\0 | xargs -0r -I__ install -m644 -D lib/__ $(DESTDIR)$(libdir)/__
 
 install-man:
-	find man -type d -printf %P\\0 | xargs -0r -I__ install -d $(DESTDIR)$(mandir)/__
-	find man -type f -name \*.[12345678] -printf %P\\0 | xargs -0r -I__ install -m644 man/__ $(DESTDIR)$(mandir)/__
+	find man -type f -name \*.[12345678] -printf %P\\0 | xargs -0r -I__ install -m644 -D man/__ $(DESTDIR)$(mandir)/__
 	find man -type f -name \*.[12345678] -printf %P\\0 | xargs -0r -I__ gzip $(DESTDIR)$(mandir)/__
 
 install-sysconf:
-	find etc -type d -printf %P\\0 | xargs -0r -I__ install -d $(DESTDIR)$(sysconfdir)/__
-	find etc -type f -not -name freight.conf -printf %P\\0 | xargs -0r -I__ install -m644 etc/__ $(DESTDIR)$(sysconfdir)/__
+	find etc -type f -not -name freight.conf -printf %P\\0 | xargs -0r -I__ install -m644 -D etc/__ $(DESTDIR)$(sysconfdir)/__
 
 uninstall: uninstall-bin uninstall-lib uninstall-man uninstall-sysconf
 


### PR DESCRIPTION
- Does not try to forcible create directories that already exist
- Also does not try to change permissions of said directories
- Works well in situations where you're using e.g. a 'staff' group for
  /usr/local
