### PR TITLE
Change SHA field labels to SHA1/SHA256 in Release file

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -174,9 +174,9 @@ EOF
 		done 3>"$TMP/md5sums" 4>"$TMP/sha1sums" 5>"$TMP/sha256sums"
 		echo "MD5Sum:"
 		cat "$TMP/md5sums"
-		echo "SHA1Sum:"
+		echo "SHA1:"
 		cat "$TMP/sha1sums"
-		echo "SHA256Sum:"
+		echo "SHA256:"
 		cat "$TMP/sha256sums"
 
 	} >"$DISTCACHE/Release"


### PR DESCRIPTION
These were previously called "SHA1Sum" and "SHA256Sum" which is not
correct according to
https://wiki.debian.org/RepositoryFormat#MD5Sum.2C_SHA1.2C_SHA256 and
makes at least certain Debian versions choke (Ubuntu seems not to mind).
Fixes #51.
