### PR TITLE
Fail hard if -c is used with a config file that does not exist

### DIFF
--- a/lib/freight/conf.sh
+++ b/lib/freight/conf.sh
@@ -33,6 +33,7 @@ do
 done
 [ "$FREIGHT_CONF" -a -f "$FREIGHT_CONF" ] && . "$FREIGHT_CONF"
 [ "$CONF" -a -f "$CONF" ] && . "$CONF"
+[ -n "$CONF" -a ! -e "$CONF" ] && echo "$0 invoked with '-c $CONF' but config file '$CONF' does not exist" && exit 1
 
 # Normalize directory names.
 VARLIB=${VARLIB%%/}


### PR DESCRIPTION
Presently, if freight commands are invoked with -c $file and $file does
not exist, freight happily continues and loads defaults from conf.sh and
other conf files. This can be confusing. This commit updates conf.sh to
bail out if $CONF is passed in but the file that $CONF points to does
not exist.
