### PR TITLE
Support source tar files in bz2 format

### DIFF
--- a/bin/freight-add
+++ b/bin/freight-add
@@ -35,7 +35,7 @@ done
 while [ "$#" -gt 0 ]
 do
 	case "$1" in
-		*.deb|*.dsc|*.orig.tar.gz|*.diff.gz|*.debian.tar.gz|*.tar.gz)
+		*.deb|*.dsc|*.orig.tar.gz|*.orig.tar.bz2|*.diff.gz|*.debian.tar.gz|*.tar.gz)
 			PATHNAMES="$PATHNAMES $1" shift;;
 		*.build|*.changes) shift;;
 		*) break;;


### PR DESCRIPTION
dpkg-buildpackage produces source tar files compressed with bz2. This simple change supports those bz2 files.
