### PR TITLE
Allow freight-add to work with relative dirs

### DIFF
--- a/bin/freight-add
+++ b/bin/freight-add
@@ -59,6 +59,7 @@ done
 # absolute paths or as partial paths of the form `<manager>/<distro>` that
 # are ultimately taken relative to the Freight library.
 cd "$VARLIB"
+TMP="${TMP#"$VARLIB/"}"
 
 # Add a file to the Freight library.  The arguments are FILENAME, DIRNAME, and
 # PATHNAME.  The first two are given fairly directly to ln(1); the final one


### PR DESCRIPTION
I have a continuous integration server that runs freight in an ephemeral directory.  I could generate a new freight.conf containing ginormous absolute pathnames, or I could just have a small and static freight.conf with relative dirs.

The latter is much nicer!

I haven't needed freight-cache or any of the other commands yet.  I may get to them soon...
