### PR TITLE
add Date field to Release file

### DIFF
--- a/lib/freight/apt.sh
+++ b/lib/freight/apt.sh
@@ -156,6 +156,7 @@ Origin: $ORIGIN
 Label: $LABEL
 Suite: $SUITE
 Codename: $DIST
+Date: $(date -R)
 Components: $(echo "$COMPS" | tr \\n " ")
 Architectures: $ARCHS
 EOF


### PR DESCRIPTION
We've been using freight to manage the RethinkDB apt repo, but it seems to be incompatible with the newest version of apt. This simple patch seems to fix the issue.

 Originally reported here https://github.com/rethinkdb/rethinkdb/issues/5174:

> With the [new release](https://mvogt.wordpress.com/2015/11/30/apt-1-1-released/) of apt-1.1, the apt repositories at http://download.rethinkdb.com/apt/ are failing to update..
> 
> ```
> $ apt update
> ...
> W: Failed to fetch http://download.rethinkdb.com/apt/dists/stretch/Release  Invalid 'Date' entry in Release file /var/lib/apt/lists/partial/download.rethinkdb.com_apt_dists_stretch_Release
> E: Some index files failed to download. They have been ignored, or old ones used instead.
> ```
