### PR TITLE
Handle the scenario where $VARLIB is a symlink

### DIFF
--- a/bin/freight-cache
+++ b/bin/freight-cache
@@ -73,7 +73,7 @@ do
 
 	# Parse the manager and distro out of the Freight library path.
 	DIR="$(readlink -f "$DIR")"
-	DIR="${DIR##"$VARLIB/"}"
+	DIR="${DIR##"$(readlink -f "$VARLIB")/"}"
 	MANAGER="$(dirname "$DIR")"
 	DIST="$(basename "$DIR")"
 


### PR DESCRIPTION
If $VARLIB (typically /var/lib/freight) is a symlink to another directory, freight-cache generates an invalid $MANAGER value. This patch fixes that. I also verified that the behavior is unchanged when $VARLIB is not a symlink.
